### PR TITLE
PATCH for Order :pickup_date validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'devise'
 gem 'activeadmin', github: 'activeadmin'
 gem 'cancancan', '~> 1.10.1'
 gem 'active_admin_datetimepicker'
+gem 'date_validator'
 
 group :development do
   # gem "spring"

--- a/Gemfile
+++ b/Gemfile
@@ -63,4 +63,5 @@ group :test do
 end
 
 group :staging, :production do
+  gem 'rails_12factor'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,11 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.4)
+    rails_stdout_logging (0.0.3)
     railties (4.2.1)
       actionpack (= 4.2.1)
       activesupport (= 4.2.1)
@@ -406,6 +411,7 @@ DEPENDENCIES
   pry-rails
   rack-timeout
   rails (= 4.2.1)
+  rails_12factor
   recipient_interceptor
   refills
   rspec-rails (~> 3.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,8 @@ GEM
       nokogiri (~> 1.5)
       rails (>= 3, < 5)
     database_cleaner (1.4.1)
+    date_validator (0.7.1)
+      activemodel
     debug_inspector (0.0.2)
     devise (3.4.1)
       bcrypt (~> 3.0)
@@ -391,6 +393,7 @@ DEPENDENCIES
   coveralls (~> 0.7.9)
   cucumber-rails
   database_cleaner
+  date_validator
   devise
   dotenv-rails
   email_validator

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -5,5 +5,8 @@ class Order < ActiveRecord::Base
 
   validates_presence_of :user
 
-  validates :pickup_time, on_or_after: lambda { Date.current }
+  #validates :pickup_time, on_or_after: lambda { Date.current }
+  #PATCHING with validator frpm 'date_validator'
+
+  validates :pickup_time, date: { after: Proc.new { Time.now }}
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,10 +1,9 @@
 class Order < ActiveRecord::Base
-  include ActiveModel::Validations
 
   has_and_belongs_to_many :menu_items
   belongs_to :user
 
   validates_presence_of :user
 
-  validates_date :pickup_time, on_or_after: lambda { Date.current }
+  validates :pickup_time, on_or_after: lambda { Date.current }
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -6,7 +6,7 @@ class Order < ActiveRecord::Base
   validates_presence_of :user
 
   #validates :pickup_time, on_or_after: lambda { Date.current }
-  #PATCHING with validator frpm 'date_validator'
+  #PATCHING with validator from 'date_validator' with a quick fix for validation message
 
-  validates :pickup_time, date: { after: Proc.new { Time.now }}
+  validates :pickup_time, date: { after: Proc.new { Time.now }, message: '%{value} didn\'t pass validation'}
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,4 +1,6 @@
 class Order < ActiveRecord::Base
+  include ActiveModel::Validations
+
   has_and_belongs_to_many :menu_items
   belongs_to :user
 

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     user
     status "MyString"
     order_time Time.now
-    pickup_time Time.now
+    pickup_time Time.now + 1.hour
     fulfillment_time Time.now
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Order, type: :model do
       it { is_expected.to validate_presence_of :user }
 
       context 'for :pickup_time' do
-        it { is_expected.to allow_value(Time.now).for :pickup_time }
+        it { is_expected.to allow_value(Time.now + 1.hour).for :pickup_time }
         it { is_expected.not_to allow_value(Faker::Time.between(3.days.ago, 2.days.ago)).for :pickup_time }
       end
     end


### PR DESCRIPTION
I was getting errors on 

```
validates_date :pickup_time, on_or_after: lambda { Date.current }
```
- added `date_validator` gem
- changed validation method for `:pickup_date` 
