### PR TITLE
PATCH: Menu and Order Factories

### DIFF
--- a/spec/factories/menus.rb
+++ b/spec/factories/menus.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :menu do
     show_category true
     title Faker::Name.name
-    start_date Date.today
-    end_date Date.today
+    start_date { Time.zone.today }
+    end_date { Time.zone.today }
   end
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,9 +1,9 @@
 FactoryGirl.define do
   factory :order do
     user
-    status "MyString"
-    order_time Time.now
-    pickup_time Time.now
-    fulfillment_time Time.now
+    status 'MyString'
+    order_time { Time.zone.now }
+    pickup_time { Time.zone.now }
+    fulfillment_time { Time.zone.now }
   end
 end


### PR DESCRIPTION
Time values in factories should be wrapped around `{}` otherwise they get interpreted at runtime.

eg: When we don't have them, say we generate a menu using Factory girl, we get the following

```
 #<Menu:0x007f84eb70d678
  id: 34,
  show_category: true,
  start_date: Mon, 18 May 2015,
  end_date: Mon, 18 May 2015,
  created_at: Mon, 04 May 2015 00:00:00 UTC +00:00,
  updated_at: Mon, 04 May 2015 00:00:00 UTC +00:00,
  title: "Lorna Daniel">,
```

 Both `created_at` and `updated_at` fields used time generated from time travel but `start_date` and `end_date` use the real time. 

reference: https://github.com/travisjeffery/timecop/issues/13#issuecomment-1242955
