### PR TITLE
Refactor menu endpoint JSON response

### DIFF
--- a/api_endpoints.md
+++ b/api_endpoints.md
@@ -15,31 +15,33 @@ Returns
 
 ```
 {
-    "date_range": "2015-05-04..2015-05-10",
-    "menus": [
+  "date_range": "2015-05-04..2015-05-10",
+  "menus": [
+    {
+      "id": 2,
+      "title": "Monday",
+      "start_date": "2015-05-04",
+      "end_date": "2015-05-04"
+      "uri": "http://localhost:3000/v1/menus/2",
+      "item_count": 2,
+      "items": [
         {
-            "menu": {
-                "id": 2,
-                "title": "Monday",
-                "start_date": "2015-05-04",
-                "end_date": "2015-05-04"
-            },
-            "uri": "http://localhost:3000/v1/menus/2",
-            "item_count": 2,
-            "items": [
-                {
-                    "item": "Kyckling",
-                    "price": "20.0",
-                    "description": "Lorem ipsum"
-                },
-                {
-                    "item": "Biff",
-                    "price": "15.0",
-                    "description": "Lorem ipsum..."
-                }
-            ]
+          "id": 1,
+          "item": "Kyckling",
+          "price": "20.0",
+          "description": "Lorem ipsum"
+          "ingredients": "something tasty, ...",
+        },
+        {
+          "id": 2,
+          "item": "Biff",
+          "price": "15.0",
+          "description": "Lorem ipsum..."
+          "ingredients": "beef, ...",
         }
-    ]
+      ]
+    }
+  ]
 }
 ```
 ##### Session
@@ -70,4 +72,3 @@ On failure
     "message": "Error with your login or password"
 }
 ```
-

--- a/app/views/api/v1/menus/_menu.json.jbuilder
+++ b/app/views/api/v1/menus/_menu.json.jbuilder
@@ -1,17 +1,17 @@
 json.cache! menu do
-  json.menu do
-    json.id menu.id
-    json.title menu.title
-    json.start_date menu.start_date.strftime('%F')
-    json.end_date menu.end_date.strftime('%F')
-  end
+  # json.menu do
+  json.id menu.id
+  json.title menu.title
+  json.start_date menu.start_date.strftime('%F')
+  json.end_date menu.end_date.strftime('%F')
+  # end
   json.uri url_for("#{request.protocol}#{request.host_with_port}#{Rails.application.routes.url_helpers.v1_menu_path(menu.id)}")
   json.item_count menu.menu_items.count
 
-
   if menu.menu_items
     json.items menu.menu_items do |item|
-      json.item item.name
+      json.id item.id
+      json.name item.name
       json.price item.price
       json.description item.description
       json.ingredients item.ingredients
@@ -19,6 +19,4 @@ json.cache! menu do
   else
     json.items '"no items"'
   end
-
-
 end

--- a/app/views/api/v1/menus/_menu.json.jbuilder
+++ b/app/views/api/v1/menus/_menu.json.jbuilder
@@ -1,22 +1,18 @@
-json.cache! menu do
-  # json.menu do
-  json.id menu.id
-  json.title menu.title
-  json.start_date menu.start_date.strftime('%F')
-  json.end_date menu.end_date.strftime('%F')
-  # end
-  json.uri url_for("#{request.protocol}#{request.host_with_port}#{Rails.application.routes.url_helpers.v1_menu_path(menu.id)}")
-  json.item_count menu.menu_items.count
+json.id menu.id
+json.title menu.title
+json.start_date menu.start_date.strftime('%F')
+json.end_date menu.end_date.strftime('%F')
+json.uri url_for("#{request.protocol}#{request.host_with_port}#{Rails.application.routes.url_helpers.v1_menu_path(menu.id)}")
+json.item_count menu.menu_items.count
 
-  if menu.menu_items
-    json.items menu.menu_items do |item|
-      json.id item.id
-      json.name item.name
-      json.price item.price
-      json.description item.description
-      json.ingredients item.ingredients
-    end
-  else
-    json.items '"no items"'
+if menu.menu_items
+  json.items menu.menu_items do |item|
+    json.id item.id
+    json.name item.name
+    json.price item.price
+    json.description item.description
+    json.ingredients item.ingredients
   end
+else
+  json.items '"no items"'
 end

--- a/spec/factories/menu_items.rb
+++ b/spec/factories/menu_items.rb
@@ -1,9 +1,8 @@
 FactoryGirl.define do
   factory :menu_item do
-    name Faker::Commerce.product_name
-    price Faker::Commerce.price
-    description Faker::Lorem.sentence(3)
-    ingredients Faker::Lorem.sentence(3)
+    name { Faker::Commerce.product_name }
+    price { Faker::Commerce.price }
+    description { Faker::Lorem.sentence(3) }
+    ingredients { Faker::Lorem.sentence(3) }
   end
-
 end

--- a/spec/factories/menus.rb
+++ b/spec/factories/menus.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :menu do
     show_category true
-    title Faker::Name.name
+    title { Faker::Name.name }
     start_date { Time.zone.today }
     end_date { Time.zone.today }
   end

--- a/spec/requests/api/v1/menu_spec.rb
+++ b/spec/requests/api/v1/menu_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe Api::V1::MenusController do
   describe 'GET /v1/menus/:id' do
-
     before do
       Timecop.freeze(Date.parse('2015-05-06').at_beginning_of_week)
       @menus = FactoryGirl.create_list(:menu, 3)
@@ -19,134 +18,132 @@ describe Api::V1::MenusController do
     end
 
     it 'returns a menu index' do
-      get "/v1/menus"
-      expect(response_json).to eq({'date_range' => '2015-05-04..2015-05-10',
-                                   'menus' =>
-                                       [
-                                           {'menu' =>
-                                                {'id' => @menus[0].id,
-                                                 'title' => @menus[0].title,
-                                                 'start_date' => @menus[0].start_date.strftime('%F'),
-                                                 'end_date' => @menus[0].end_date.strftime('%F')},
-                                            'uri' => "http://www.example.com/v1/menus/#{@menus[0].id}",
-                                            'item_count' => 3,
-                                            'items' =>
-                                                [
-                                                    {
-                                                        'item' => @menu_items[0].name,
-                                                        'price' => @menu_items[0].price.to_f.to_s,
-                                                        'description' => @menu_items[0].description,
-                                                        'ingredients' => @menu_items[0].ingredients
-                                                    },
-                                                    {
-                                                        'item' => @menu_items[1].name,
-                                                        'price' => @menu_items[1].price.to_f.to_s,
-                                                        'description' => @menu_items[1].description,
-                                                        'ingredients' => @menu_items[1].ingredients
-                                                    },
-                                                    {
-                                                        'item' => @menu_items[2].name,
-                                                        'price' => @menu_items[2].price.to_f.to_s,
-                                                        'description' => @menu_items[2].description,
-                                                        'ingredients' => @menu_items[2].ingredients
-                                                    }
-                                                ]
-                                           },
-                                           {'menu' =>
-                                                {'id' => @menus[1].id,
-                                                 'title' => @menus[1].title,
-                                                 'start_date' => @menus[1].start_date.strftime('%F'),
-                                                 'end_date' => @menus[1].end_date.strftime('%F')},
-                                            'uri' => "http://www.example.com/v1/menus/#{@menus[1].id}",
-                                            'item_count' => 3,
-                                            'items' =>
-                                                [
-                                                    {
-                                                        'item' => @menu_items[0].name,
-                                                        'price' => @menu_items[0].price.to_f.to_s,
-                                                        'description' => @menu_items[0].description,
-                                                        'ingredients' => @menu_items[0].ingredients
-                                                    },
-                                                    {
-                                                        'item' => @menu_items[1].name,
-                                                        'price' => @menu_items[1].price.to_f.to_s,
-                                                        'description' => @menu_items[1].description,
-                                                        'ingredients' => @menu_items[1].ingredients
-                                                    },
-                                                    {
-                                                        'item' => @menu_items[2].name,
-                                                        'price' => @menu_items[2].price.to_f.to_s,
-                                                        'description' => @menu_items[2].description,
-                                                        'ingredients' => @menu_items[2].ingredients
-                                                    }
-                                                ]
-                                           },
-                                           {'menu' =>
-                                                {'id' => @menus[2].id,
-                                                 'title' => @menus[2].title,
-                                                 'start_date' => @menus[2].start_date.strftime('%F'),
-                                                 'end_date' => @menus[2].end_date.strftime('%F')},
-                                            'uri' => "http://www.example.com/v1/menus/#{@menus[2].id}",
-                                            'item_count' => 3,
-                                            'items' =>
-                                                [
-                                                    {
-                                                        'item' => @menu_items[0].name,
-                                                        'price' => @menu_items[0].price.to_f.to_s,
-                                                        'description' => @menu_items[0].description,
-                                                        'ingredients' => @menu_items[0].ingredients
-                                                    },
-                                                    {
-                                                        'item' => @menu_items[1].name,
-                                                        'price' => @menu_items[1].price.to_f.to_s,
-                                                        'description' => @menu_items[1].description,
-                                                        'ingredients' => @menu_items[1].ingredients
-                                                    },
-                                                    {
-                                                        'item' => @menu_items[2].name,
-                                                        'price' => @menu_items[2].price.to_f.to_s,
-                                                        'description' => @menu_items[2].description,
-                                                        'ingredients' => @menu_items[2].ingredients
-                                                    }
-                                                ]
-                                           }
-                                       ]
-                                  })
+      get '/v1/menus'
+      expect(response_json).to eq('date_range' => '2015-05-04..2015-05-10',
+                                  'menus' => [{
+                                    'id' => @menus[0].id,
+                                    'title' => @menus[0].title,
+                                    'start_date' => @menus[0].start_date.strftime('%F'),
+                                    'end_date' => @menus[0].end_date.strftime('%F'),
+                                    'uri' => "http://www.example.com/v1/menus/#{@menus[0].id}",
+                                    'item_count' => 3,
+                                    'items' => [
+                                      {
+                                        'id' => @menu_items[0].id,
+                                        'name' => @menu_items[0].name,
+                                        'price' => @menu_items[0].price.to_f.to_s,
+                                        'description' => @menu_items[0].description,
+                                        'ingredients' => @menu_items[0].ingredients
+                                      },
+                                      {
+                                        'id' => @menu_items[1].id,
+                                        'name' => @menu_items[1].name,
+                                        'price' => @menu_items[1].price.to_f.to_s,
+                                        'description' => @menu_items[1].description,
+                                        'ingredients' => @menu_items[1].ingredients
+                                      },
+                                      {
+                                        'id' => @menu_items[2].id,
+                                        'name' => @menu_items[2].name,
+                                        'price' => @menu_items[2].price.to_f.to_s,
+                                        'description' => @menu_items[2].description,
+                                        'ingredients' => @menu_items[2].ingredients
+                                      }
+                                    ]
+                                  }, {
+                                    'id' => @menus[1].id,
+                                    'title' => @menus[1].title,
+                                    'start_date' => @menus[1].start_date.strftime('%F'),
+                                    'end_date' => @menus[1].end_date.strftime('%F'),
+                                    'uri' => "http://www.example.com/v1/menus/#{@menus[1].id}",
+                                    'item_count' => 3,
+                                    'items' => [
+                                      {
+                                        'id' => @menu_items[0].id,
+                                        'name' => @menu_items[0].name,
+                                        'price' => @menu_items[0].price.to_f.to_s,
+                                        'description' => @menu_items[0].description,
+                                        'ingredients' => @menu_items[0].ingredients
+                                      },
+                                      {
+                                        'id' => @menu_items[1].id,
+                                        'name' => @menu_items[1].name,
+                                        'price' => @menu_items[1].price.to_f.to_s,
+                                        'description' => @menu_items[1].description,
+                                        'ingredients' => @menu_items[1].ingredients
+                                      },
+                                      {
+                                        'id' => @menu_items[2].id,
+                                        'name' => @menu_items[2].name,
+                                        'price' => @menu_items[2].price.to_f.to_s,
+                                        'description' => @menu_items[2].description,
+                                        'ingredients' => @menu_items[2].ingredients
+                                      }
+                                    ]
+                                  }, {
+                                    'id' => @menus[2].id,
+                                    'title' => @menus[2].title,
+                                    'start_date' => @menus[2].start_date.strftime('%F'),
+                                    'end_date' => @menus[2].end_date.strftime('%F'),
+                                    'uri' => "http://www.example.com/v1/menus/#{@menus[2].id}",
+                                    'item_count' => 3,
+                                    'items' => [
+                                      {
+                                        'id' => @menu_items[0].id,
+                                        'name' => @menu_items[0].name,
+                                        'price' => @menu_items[0].price.to_f.to_s,
+                                        'description' => @menu_items[0].description,
+                                        'ingredients' => @menu_items[0].ingredients
+                                      },
+                                      {
+                                        'id' => @menu_items[1].id,
+                                        'name' => @menu_items[1].name,
+                                        'price' => @menu_items[1].price.to_f.to_s,
+                                        'description' => @menu_items[1].description,
+                                        'ingredients' => @menu_items[1].ingredients
+                                      },
+                                      {
+                                        'id' => @menu_items[2].id,
+                                        'name' => @menu_items[2].name,
+                                        'price' => @menu_items[2].price.to_f.to_s,
+                                        'description' => @menu_items[2].description,
+                                        'ingredients' => @menu_items[2].ingredients
+                                      }
+                                    ]
+                                  }])
     end
 
     it 'returns a menu by :id' do
       menu = @menus[0]
       get "/v1/menus/#{menu.id}"
-      expect(response_json).to eq({'menu' =>
-                                       {'id' => @menus[0].id,
-                                        'title' => @menus[0].title,
-                                        'start_date' => @menus[0].start_date.strftime('%F'),
-                                        'end_date' => @menus[0].end_date.strftime('%F')},
-                                   'uri' => "http://www.example.com/v1/menus/#{@menus[0].id}",
-                                   'item_count' => 3,
-                                   'items' =>
-                                       [
-                                           {
-                                               'item' => @menu_items[0].name,
-                                               'price' => @menu_items[0].price.to_f.to_s,
-                                               'description' => @menu_items[0].description,
-                                               'ingredients' => @menu_items[0].ingredients
-                                           },
-                                           {
-                                               'item' => @menu_items[1].name,
-                                               'price' => @menu_items[1].price.to_f.to_s,
-                                               'description' => @menu_items[1].description,
-                                               'ingredients' => @menu_items[1].ingredients
-                                           },
-                                           {
-                                               'item' => @menu_items[2].name,
-                                               'price' => @menu_items[2].price.to_f.to_s,
-                                               'description' => @menu_items[2].description,
-                                               'ingredients' => @menu_items[2].ingredients
-                                           }
-                                       ]
-                                  })
+      expect(response_json).to eq('id' => @menus[0].id,
+                                  'title' => @menus[0].title,
+                                  'start_date' => @menus[0].start_date.strftime('%F'),
+                                  'end_date' => @menus[0].end_date.strftime('%F'),
+                                  'uri' => "http://www.example.com/v1/menus/#{@menus[0].id}",
+                                  'item_count' => 3,
+                                  'items' => [
+                                    {
+                                      'id' => @menu_items[0].id,
+                                      'name' => @menu_items[2].name,
+                                      'price' => @menu_items[0].price.to_f.to_s,
+                                      'description' => @menu_items[0].description,
+                                      'ingredients' => @menu_items[0].ingredients
+                                    }, {
+                                      'id' => @menu_items[1].id,
+                                      'name' => @menu_items[1].name,
+                                      'price' => @menu_items[1].price.to_f.to_s,
+                                      'description' => @menu_items[1].description,
+                                      'ingredients' => @menu_items[1].ingredients
+                                    }, {
+                                      'id' => @menu_items[2].id,
+                                      'name' => @menu_items[2].name,
+                                      'price' => @menu_items[2].price.to_f.to_s,
+                                      'description' => @menu_items[2].description,
+                                      'ingredients' => @menu_items[2].ingredients
+                                    }
+                                  ]
+                                 )
     end
   end
 end
-

--- a/spec/requests/api/v1/menu_spec.rb
+++ b/spec/requests/api/v1/menu_spec.rb
@@ -125,7 +125,7 @@ describe Api::V1::MenusController do
                                   'items' => [
                                     {
                                       'id' => @menu_items[0].id,
-                                      'name' => @menu_items[2].name,
+                                      'name' => @menu_items[0].name,
                                       'price' => @menu_items[0].price.to_f.to_s,
                                       'description' => @menu_items[0].description,
                                       'ingredients' => @menu_items[0].ingredients


### PR DESCRIPTION
**PT: https://www.pivotaltracker.com/story/show/95106938**

responses from `/v1/menus` will now have the following structure

``` javascript
{
  "date_range": "2015-05-04..2015-05-10",
  "menus": [
    {
      "id": 2,
      "title": "Monday",
      "start_date": "2015-05-04",
      "end_date": "2015-05-04"
      "uri": "http://localhost:3000/v1/menus/2",
      "item_count": 2,
      "items": [
        {
          "id": 1,
          "item": "Kyckling",
          "price": "20.0",
          "description": "Lorem ipsum"
          "ingredients": "something tasty, ...",
        },
        {
          "id": 2,
          "item": "Biff",
          "price": "15.0",
          "description": "Lorem ipsum..."
          "ingredients": "beef, ...",
        }
      ]
    }
  ]
}
```

Disable caching => **PT: https://www.pivotaltracker.com/story/show/94062700**
