### PR TITLE
PATCH: users  is_admin  default:false

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ActiveRecord::Base
 
   after_create :ensure_authentication_token
 
-  scope :clients, -> { where.not(is_admin: true) }
+  scope :clients, -> { where(is_admin: [false, nil]) }
   scope :admins, -> { where(is_admin: true) }
 
   def admin?

--- a/db/migrate/20150527075954_add_default_to_user_is_admin.rb
+++ b/db/migrate/20150527075954_add_default_to_user_is_admin.rb
@@ -1,0 +1,27 @@
+class AddDefaultToUserIsAdmin < ActiveRecord::Migration
+  def up
+    change_column :users, :is_admin, :boolean, default: false
+    is_admin_from_nil_to_false
+    test_changes
+  end
+
+  def down
+    change_column :users, :is_admin, :boolean
+  end
+
+  private
+
+  def is_admin_from_nil_to_false
+    User.find_each do |user|
+      user.update_attributes(is_admin: false) if user.is_admin == nil
+    end
+  end
+
+  def test_changes
+    User.find_each do |nil_user|
+      if nil_user.is_admin == nil
+        raise StandardError, "Migration could not change all users with 'is_admin: nil' to 'is_admin: false'"
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150523181431) do
+ActiveRecord::Schema.define(version: 20150527075954) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -108,15 +108,15 @@ ActiveRecord::Schema.define(version: 20150523181431) do
 
   create_table "users", force: :cascade do |t|
     t.string   "name"
-    t.boolean  "is_admin"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.boolean  "is_admin",               default: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
+    t.string   "email",                  default: "",    null: false
+    t.string   "encrypted_password",     default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",          default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"


### PR DESCRIPTION
Added migration: `users` have `is_admin` column with `default: false` (instead of nil) 

Notice: I added `test_changes` after the migration ran to check if everything worked well. If `test_changes` fails then the migration is rolled back and all database transactions are canceled.

After this, notice all the client users in ActiveAdmin.
