### PR TITLE
PATCH: Refactor session api endpoint

### DIFF
--- a/api_endpoints.md
+++ b/api_endpoints.md
@@ -79,36 +79,106 @@ Request format:
 Returns
 
 ```
+-
 ```
 
 ##### Authentication
 
 Register:
 > `user#create` - will register a new user and return the email and token in the same format that Log_in does.
-Request: `curl -X POST http://localhost:3000/v1/users --data "name=John&email=user@tma.org&password=password&password_confirmation=password"`
-Response valid: `{"user":{"name"=>"User Name","email":"user@tma.org"},"authentication_token":{"token":"weREXP7z3TeaRqyznzrt"}}`
-Response invalid: `{"message":["Email has already been taken"]}`
+
+Request:
+```shell
+curl -X POST http://localhost:3000/v1/users --data "name=John&email=user@tma.org&password=password&password_confirmation=password"
+```
+Response valid:
+```javascript
+{
+  "user": {
+    "id":"1",
+    "name":"User Name",
+    "email":"user@tma.org"
+  },
+  "authentication_token": {
+    "token":"weREXP7z3TeaRqyznzrt"
+  }
+}`
+```
+
+Response invalid:
+```javascript
+{
+  "message": ["Email has already been taken"]
+}
+```
 
 Log_in: (generates new token if missing)
 >`session#get_token` - will return email and token based on provided credentials (email and password)
-Request: `curl -X POST http://localhost:3000/v1/sessions --data "email=user@tma.org&password=password"`
-Response valid: `{"user":{"name"=>"User Name","email":"user@tma.org"},"authentication_token":{"token":"zJ894PziZMP3yCdaZSSw"}}`
-Response invalid: `{"message":"Email or password is incorrect"}`
+
+Request:
+```shell
+curl -X POST http://localhost:3000/v1/sessions --data "email=user@tma.org&password=password"
+```
+
+Response valid:
+```javascript
+{
+  "user":{
+    "id" => "2"
+    "name"=>"User Name",
+    "email":"user@tma.org"
+  },
+  "authentication_token": {
+    "token":"zJ894PziZMP3yCdaZSSw"
+  }
+}
+```
+
+Response invalid:
+```javascript
+{
+  "message": "Email or password is incorrect"
+}
+```
 
 Log_out: optional (it is just clearing the stored token)
 >`session#clear_token` - will reset the token based on the authorised user (current_user). Can be called on logout with/without waiting for the response.
-Request: `curl -X DELETE http://localhost:3000/v1/sessions -H "token: c-LXmsFavPiCEBRvchxe"`
-Response valid: `{"message":"Token successfully cleared"}`
-Response invalid: `{"message":"Token clear failed"}`
+
+Request:
+```shell
+curl -X DELETE http://localhost:3000/v1/sessions -H "token: c-LXmsFavPiCEBRvchxe"
+```
+
+Response valid:
+```javascript
+{
+  "message": "Token successfully cleared"
+}
+```
+
+Response invalid:
+```javascript
+{
+  "message": "Token clear failed"
+}
+```
 
 Every authorised request:
 >Should have correct headers:
-`curl -X GET http://localhost:3000/v1/private_action -H "token: c-LXmsFavPiCEBRvchxe"`
-Otherwise Response invalid: `{"message":"Access Forbidden"}`
+```shell
+curl -X GET http://localhost:3000/v1/private_action -H "token: c-LXmsFavPiCEBRvchxe"
+```
+
+Otherwise Response invalid:
+```javascript
+{
+  "message": "Access Forbidden"
+}
+```
 
 `authenticate_api_user` method will check that the request has correct headers['token'] to authorize actions. It is not creating sessions, it is checking token directly from db.
 Use on restricted controller actions with:  `before_action :authenticate_api_user, only: [:restricted_action]`
 Once authorized, controllers and views have access to instance var: `current_user` (AR object)
-If authentication fails, the api will return: `{"message":"Access Forbidden"}`
+If authentication fails, the api will return: `{"message": "Access Forbidden"}`
 
 Postman link: https://www.getpostman.com/collections/8377c2b915864d6eda84

--- a/app/views/api/v1/sessions/_session.json.jbuilder
+++ b/app/views/api/v1/sessions/_session.json.jbuilder
@@ -1,10 +1,9 @@
 json.cache! user do
   json.user do
+    json.id user.id
     json.name user.name
     json.email user.email
-    if user.admin?
-      json.is_admin 'true'
-    end
+    json.is_admin 'true' if user.admin?
   end
 
   json.authentication_token do

--- a/spec/requests/api/v1/session_spec.rb
+++ b/spec/requests/api/v1/session_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe Api::V1::SessionsController do
   describe 'POST /v1/sessions' do
-
     before do
       @admin = FactoryGirl.create(:user, is_admin: true)
       @user = FactoryGirl.create(:user)
@@ -12,59 +11,57 @@ describe Api::V1::SessionsController do
       it 'valid credentials returns user & token' do
         post '/v1/sessions', "email=#{@admin.email}&password=#{@admin.password}"
 
-        expect(response_json).to eq({'user' => {
-                                        'name' => @admin.name,
-                                        'email' => @admin.email,
-                                        'is_admin' => "#{@admin.is_admin}"
+        expect(response_json).to eq('user' => {
+                                      'id' => @admin.id,
+                                      'name' => @admin.name,
+                                      'email' => @admin.email,
+                                      'is_admin' => "#{@admin.is_admin}"
                                     },
-                                     'authentication_token' => {
-                                         'token' => @admin.authentication_token
-                                     }
+                                    'authentication_token' => {
+                                      'token' => @admin.authentication_token
                                     })
         expect(@admin.authentication_token).to_not be nil
       end
 
       it 'invalid password returns error message' do
         post '/v1/sessions', "email=#{@admin.email}&password=bogus"
-        expect(response_json).to eq({ 'message' => 'Email or password is incorrect' })
+        expect(response_json).to eq('message' => 'Email or password is incorrect')
         expect(response.status).to eq 401
       end
 
       it 'invalid email returns error message' do
         post '/v1/sessions', "email=bogus&password=#{@admin.password}"
-        expect(response_json).to eq({ 'message' => 'Email or password is incorrect' })
+        expect(response_json).to eq('message' => 'Email or password is incorrect')
         expect(response.status).to eq 401
       end
-
     end
 
     describe 'client login: get_token action' do
       it 'valid credentials returns user & token' do
         post '/v1/sessions', "email=#{@user.email}&password=#{@user.password}"
 
-        expect(response_json).to eq({'user' => {
-                                        'name' => @user.name,
-                                        'email' => @user.email
+        expect(response_json).to eq('user' => {
+                                      'id' => @user.id,
+                                      'name' => @user.name,
+                                      'email' => @user.email
                                     },
-                                     'authentication_token' => {
-                                         'token' => @user.authentication_token
-                                     }
+                                    'authentication_token' => {
+                                      'token' => @user.authentication_token
                                     })
         expect(@user.authentication_token).to_not be nil
       end
 
       it 'invalid password returns error message' do
         post '/v1/sessions', "email=#{@user.email}&password=bogus"
-        expect(response_json).to eq({ 'message' => 'Email or password is incorrect' })
+        expect(response_json).to eq('message' => 'Email or password is incorrect')
         expect(response.status).to eq 401
       end
 
       it 'invalid email returns error message' do
         post '/v1/sessions', "email=bogus&password=#{@user.password}"
-        expect(response_json).to eq({ 'message' => 'Email or password is incorrect' })
+        expect(response_json).to eq('message' => 'Email or password is incorrect')
         expect(response.status).to eq 401
       end
-
     end
 
     describe 'logout: clear_token action' do
@@ -72,7 +69,7 @@ describe Api::V1::SessionsController do
         authenticate_user @user
       end
 
-      it "is successful" do
+      it 'is successful' do
         delete '/v1/sessions'
         @user.reload
 
@@ -81,16 +78,13 @@ describe Api::V1::SessionsController do
         expect(@user.authentication_token).to be nil
       end
 
-      it "is unsuccessful" do
+      it 'is unsuccessful' do
         expect(@user).to receive(:clear_authentication_token!).and_return(false)
         delete '/v1/sessions'
 
         expect(response.status).to eq 500
         expect(response_json['message']).to_not be nil
       end
-
-
     end
   end
-
 end


### PR DESCRIPTION
- The user_id is needed on the front end when placing an order.
- Cleanup api endpoint documentation.
