### PR TITLE
ActionMailer emails managed via ActiveAdmin

### DIFF
--- a/app/admin/admin.rb
+++ b/app/admin/admin.rb
@@ -7,8 +7,20 @@ ActiveAdmin.register User, as: 'Admins' do
   permit_params :email, :password, :password_confirmation, 
                 :name, :is_admin, :receive_notifications, 
                 :order_acknowledge_email
-
-
+  
+  # the following controller override allows user to edit admin resources
+  # without re-entering the password (and confirmation) for every update
+  # http://stackoverflow.com/questions/15292247/activeadmin-how-to-leave-user-password-unchanged
+  controller do
+    def update
+      if params[:user][:password].blank?
+        params[:user].delete("password")
+        params[:user].delete("password_confirmation")
+      end
+      super
+    end
+  end
+                  
   index do
     selectable_column
     #id_column

--- a/app/admin/admin.rb
+++ b/app/admin/admin.rb
@@ -4,7 +4,8 @@ ActiveAdmin.register User, as: 'Admins' do
   scope_to do
     User.admins
   end
-  permit_params :email, :password, :password_confirmation
+  permit_params :email, :password, :password_confirmation, 
+                :name, :receive_notifications, :is_admin
 
 
   index do
@@ -12,6 +13,7 @@ ActiveAdmin.register User, as: 'Admins' do
     #id_column
     column :name
     column :email
+    column :receive_notifications
     column 'Member since', :created_at
     actions
   end
@@ -24,9 +26,12 @@ ActiveAdmin.register User, as: 'Admins' do
 
   form do |f|
     f.inputs "User Details" do
+      f.semantic_errors *f.object.errors.keys
+      f.input :name
       f.input :email
       f.input :password
       f.input :password_confirmation
+      f.input :receive_notifications
       f.input :is_admin
     end
     f.actions

--- a/app/admin/admin.rb
+++ b/app/admin/admin.rb
@@ -5,7 +5,8 @@ ActiveAdmin.register User, as: 'Admins' do
     User.admins
   end
   permit_params :email, :password, :password_confirmation, 
-                :name, :receive_notifications, :is_admin
+                :name, :is_admin, :receive_notifications, 
+                :order_acknowledge_email
 
 
   index do
@@ -14,6 +15,7 @@ ActiveAdmin.register User, as: 'Admins' do
     column :name
     column :email
     column :receive_notifications
+    column "Send 'Order Received' Email", :order_acknowledge_email
     column 'Member since', :created_at
     actions
   end
@@ -31,8 +33,9 @@ ActiveAdmin.register User, as: 'Admins' do
       f.input :email
       f.input :password
       f.input :password_confirmation
-      f.input :receive_notifications
       f.input :is_admin
+      f.input :receive_notifications
+      f.input :order_acknowledge_email, label: 'Use this email address to send order acknowledgement to the customer'
     end
     f.actions
   end

--- a/app/admin/menu_item.rb
+++ b/app/admin/menu_item.rb
@@ -19,6 +19,7 @@ ActiveAdmin.register MenuItem, as: 'Products' do
       f.input :price
       f.input :description
       f.input :ingredients
+      f.input :receive_notifications
       f.input :image, :as => :formtastic_attachinary
     end
     f.actions

--- a/app/admin/menu_item.rb
+++ b/app/admin/menu_item.rb
@@ -19,7 +19,6 @@ ActiveAdmin.register MenuItem, as: 'Products' do
       f.input :price
       f.input :description
       f.input :ingredients
-      f.input :receive_notifications
       f.input :image, :as => :formtastic_attachinary
     end
     f.actions

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV['order_receipt_from_email']
+  default from: User.order_acknowledge_email_address
   layout 'mailer'
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"  # CHANGE TO PRODUCTION SETTING
+  default from: ENV['order_receipt_from_email']
   layout 'mailer'
 end

--- a/app/mailers/order_notifier.rb
+++ b/app/mailers/order_notifier.rb
@@ -12,13 +12,8 @@ class OrderNotifier < ApplicationMailer
 
   def kitchen(order)
     @order = order
-    if Rails.env.test?
-      to_email = ENV['order_receipt_from_email']
-    else
-      to_email = User.notification_email_list || ENV['order_receipt_from_email']
-    end
-        
-    mail to: to_email, subject: 'Order Received' do |format|
+
+    mail to: User.notification_email_list, subject: 'Order Received' do |format|
       format.html
       format.text
     end

--- a/app/mailers/order_notifier.rb
+++ b/app/mailers/order_notifier.rb
@@ -3,7 +3,8 @@ class OrderNotifier < ApplicationMailer
   def customer(order)
     @order = order
 
-    mail to: order.user.email, subject: 'Take-Away Order Receipt Confirmation' do |format|
+    mail to: @order.user.email, 
+            subject: 'Take-Away Order Receipt Confirmation' do |format|
       format.html
       format.text
     end
@@ -11,9 +12,13 @@ class OrderNotifier < ApplicationMailer
 
   def kitchen(order)
     @order = order
-    
-    # CHANGE 'TO' ADDRESS TO PRODUCTION SETTING
-    mail to: 'patmbolger@gmail.com', subject: 'Order Received' do |format|
+    if Rails.env.test?
+      to_email = ENV['order_receipt_from_email']
+    else
+      to_email = User.notification_email_list || ENV['order_receipt_from_email']
+    end
+        
+    mail to: to_email, subject: 'Order Received' do |format|
       format.html
       format.text
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,9 @@ class User < ActiveRecord::Base
          :token_authenticatable
   has_many :orders
   validates :name, presence: true
+  
+  validates_uniqueness_of :order_acknowledge_email,
+            conditions: -> { where.not(order_acknowledge_email: false) }
 
   after_create :ensure_authentication_token
 
@@ -19,7 +22,17 @@ class User < ActiveRecord::Base
   end
   
   def self.notification_email_list
+    # Returns Array of email address(es)
     User.where(is_admin: true, receive_notifications: true).pluck(:email)
+  end
+  
+  def self.order_acknowledge_email_address
+    # Returns email address (string)
+    if (user = User.find_by(is_admin: true, order_acknowledge_email: true))
+      user.email
+    else
+      ENV['order_receipt_from_email']
+    end
   end
   
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,8 +22,12 @@ class User < ActiveRecord::Base
   end
   
   def self.notification_email_list
-    # Returns Array of email address(es)
-    User.where(is_admin: true, receive_notifications: true).pluck(:email)
+    if (email_list = User.where(is_admin: true, receive_notifications: true).pluck(:email))
+      email_list
+    else
+      ENV['order_receipt_from_email']
+    end
+       
   end
   
   def self.order_acknowledge_email_address

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,4 +17,9 @@ class User < ActiveRecord::Base
   def admin?
     self.is_admin
   end
+  
+  def self.notification_email_list
+    User.where(is_admin: true, receive_notifications: true).pluck(:email)
+  end
+  
 end

--- a/config/application.yml
+++ b/config/application.yml
@@ -17,4 +17,6 @@ SMTP_PASSWORD: '38LjEPStn-'  # password for sendgrid account
 SMTP_DOMAIN:  'herokuapp.com'
 SMTP_ADDRESS: 'smtp.sendgrid.net'
 
+order_receipt_from_email: 'tma_kitchen@gmail.org'
+
 

--- a/config/application.yml
+++ b/config/application.yml
@@ -1,0 +1,20 @@
+# Add configuration values here, as shown below.
+#
+# pusher_app_id: "2954"
+# pusher_key: 7381a978f7dd7f9a1117
+# pusher_secret: abdc3b896a0ffb85d373
+# stripe_api_key: sk_test_2J0l093xOyW72XUYJHE4Dv2r
+# stripe_publishable_key: pk_test_ro9jV5SNwGb1yYlQfzG17LHK
+#
+# production:
+#   stripe_api_key: sk_live_EeHnL644i6zo4Iyq4v1KdV9H
+#   stripe_publishable_key: pk_live_9lcthxpSIHbGwmdO941O1XVU
+
+# See Figaro documentation for 
+
+SMTP_USERNAME: 'patmbolger'  # username for sendgrid account 
+SMTP_PASSWORD: '38LjEPStn-'  # password for sendgrid account
+SMTP_DOMAIN:  'herokuapp.com'
+SMTP_ADDRESS: 'smtp.sendgrid.net'
+
+

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -1,0 +1,22 @@
+# Add configuration values here, as shown below.
+#
+# pusher_app_id: "2954"
+# pusher_key: 7381a978f7dd7f9a1117
+# pusher_secret: abdc3b896a0ffb85d373
+# stripe_api_key: sk_test_2J0l093xOyW72XUYJHE4Dv2r
+# stripe_publishable_key: pk_test_ro9jV5SNwGb1yYlQfzG17LHK
+#
+# production:
+#   stripe_api_key: sk_live_EeHnL644i6zo4Iyq4v1KdV9H
+#   stripe_publishable_key: pk_live_9lcthxpSIHbGwmdO941O1XVU
+
+# See Figaro documentation for 
+
+SMTP_USERNAME: 'patmbolger'  # username for sendgrid account 
+SMTP_PASSWORD: '38LjEPStn-'  # password for sendgrid account
+SMTP_DOMAIN:  'herokuapp.com'
+SMTP_ADDRESS: 'smtp.sendgrid.net'
+
+order_receipt_from_email: 'tma_kitchen@gmail.org'
+
+

--- a/db/migrate/20150608172852_add_receive_notifications_to_user.rb
+++ b/db/migrate/20150608172852_add_receive_notifications_to_user.rb
@@ -1,0 +1,5 @@
+class AddReceiveNotificationsToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :receive_notifications, :boolean, default: false
+  end
+end

--- a/db/migrate/20150609222343_add_order_ack_email_to_user.rb
+++ b/db/migrate/20150609222343_add_order_ack_email_to_user.rb
@@ -1,0 +1,5 @@
+class AddOrderAckEmailToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :order_acknowledge_email, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150608172852) do
+ActiveRecord::Schema.define(version: 20150609222343) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,21 +113,22 @@ ActiveRecord::Schema.define(version: 20150608172852) do
 
   create_table "users", force: :cascade do |t|
     t.string   "name"
-    t.boolean  "is_admin",               default: false
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
-    t.string   "email",                  default: "",    null: false
-    t.string   "encrypted_password",     default: "",    null: false
+    t.boolean  "is_admin",                default: false
+    t.datetime "created_at",                              null: false
+    t.datetime "updated_at",                              null: false
+    t.string   "email",                   default: "",    null: false
+    t.string   "encrypted_password",      default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,     null: false
+    t.integer  "sign_in_count",           default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
     t.inet     "last_sign_in_ip"
     t.string   "authentication_token"
-    t.boolean  "receive_notifications",  default: false
+    t.boolean  "receive_notifications",   default: false
+    t.boolean  "order_acknowledge_email", default: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150527185325) do
+ActiveRecord::Schema.define(version: 20150608172852) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 20150527185325) do
     t.inet     "current_sign_in_ip"
     t.inet     "last_sign_in_ip"
     t.string   "authentication_token"
+    t.boolean  "receive_notifications",  default: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,8 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-User.create(email: 'admin@tma.org', password: 'password', name: 'Admin', is_admin: true, authentication_token: '2-pvxogfa5ah8jtoGb7D')
+User.create(email: 'admin@tma.org', password: 'password', name: 'Admin', is_admin: true,
+receive_notifications: true, authentication_token: '2-pvxogfa5ah8jtoGb7D')
 User.create(email: 'client@tma.org', password: 'password', name: 'Client', is_admin: false)
 
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,7 +7,9 @@
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
 User.create(email: 'admin@tma.org', password: 'password', name: 'Admin', is_admin: true,
-receive_notifications: true, authentication_token: '2-pvxogfa5ah8jtoGb7D')
+receive_notifications: true, order_acknowledge_email: true,
+authentication_token: '2-pvxogfa5ah8jtoGb7D')
+
 User.create(email: 'client@tma.org', password: 'password', name: 'Client', is_admin: false)
 
 

--- a/features/dashboard.feature
+++ b/features/dashboard.feature
@@ -4,9 +4,9 @@ Feature: As an admin
 
   Background:
     Given the following users exist:
-      | name     | email          | password | is_admin |
-      | Admin    | admin@tma.org  | password | true     |
-      | Client 1 | client@tma.org | password | false    |
+      | name     | email          | password | is_admin | receive_notifications | order_acknowledge_email|
+      | Admin    | admin@tma.org  | password | true     | true                  | true                   |
+      | Client 1 | client@tma.org | password | false    | false                 | false                  |
 
 
   Scenario: Access the sign in page

--- a/features/dashboard.feature
+++ b/features/dashboard.feature
@@ -23,6 +23,30 @@ Feature: As an admin
     When I click the "Dashboard" link
     And I should see link "Clients"
     And I should see link "Admins"
+    
+  Scenario: Change password
+    Given I am logged in as admin
+    And I am on the "Admins" page
+    And I click the "Edit" link for "Admin"
+    Then I should be on the edit page for user "Admin"
+    And I fill in "user_password" with "new_password"
+    And I fill in "user_password_confirmation" with "new_password"
+    And I click "Update User" button
+    Then I should be on the view page for user "Admin"
+    And I should see "User was successfully updated."
+    
+  Scenario: Change email settings
+    Given I am logged in as admin
+    And I am on the "Admins" page
+    And I click the "Edit" link for "Admin"
+    Then I should be on the edit page for user "Admin"
+    And I uncheck "Receive notifications"
+    And I uncheck "Use this email address to send order acknowledgement to the customer"
+    And I click "Update User" button
+    Then I should be on the view page for user "Admin"
+    And I should see "User was successfully updated."
+    And I should see "Receive Notifications false"
+    And I should see "Order Acknowledge Email false"
 
   Scenario: Login as Client
     Given I am on the "login" page

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -22,6 +22,10 @@ When(/^I click the "([^"]*)" link$/) do |link|
   click_link link
 end
 
+When(/^I uncheck "([^"]*)"$/) do |checkbox|
+  uncheck checkbox
+end
+
 When(/^I focus on input field with id "([^"]*)"$/) do |element|
   id = element.downcase.tr!(' ', '_')
   page.execute_script "$('##{id}').focus();"

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -15,6 +15,10 @@ def path_to(page_name, id = '')
       admin_menus_path
     when 'orders' then
       admin_orders_path
+    when 'admins' then
+      admin_admins_path
+    when 'edit admin'then
+      edit_admin_admin_path
     else
       raise('path to specified is not listed in #path_to')
   end
@@ -29,6 +33,15 @@ Given /^I am on the "([^"]*)" page$/ do |page|
   visit path_to(page)
 end
 
+Then(/^I should be on the edit page for user "([^"]*)"$/) do |user_name|
+  user = User.find_by(name: user_name)
+  expect(current_path).to eq edit_admin_admin_path(user)
+end
+
+Then(/^I should be on the view page for user "([^"]*)"$/) do |user_name|
+  user = User.find_by(name: user_name)
+  expect(current_path).to eq admin_admin_path(user)
+end
 
 Then(/^I should be on the edit page for Menu Item "([^"]*)"$/) do |item|
   product = MenuItem.find_by(name: item)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,4 +5,13 @@ FactoryGirl.define do
     password 'Pa$sw0rd'
     is_admin false
   end
+  
+  factory :kitchen_user, class: User do
+    name { Faker::Name.name }
+    email { Faker::Internet.email }
+    password 'Pa$sw0rd'
+    is_admin true
+    receive_notifications true
+  end
+
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,12 +6,10 @@ FactoryGirl.define do
     is_admin false
   end
   
-  factory :kitchen_user, class: User do
-    name { Faker::Name.name }
-    email { Faker::Internet.email }
-    password 'Pa$sw0rd'
+  factory :kitchen_user, parent: :user do
     is_admin true
     receive_notifications true
+    order_acknowledge_email true
   end
 
 end

--- a/spec/mailers/order_notifier_spec.rb
+++ b/spec/mailers/order_notifier_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe OrderNotifier, :type => :mailer do
     end
     
     it 'should specify correct from address' do
-      expect(mail).to deliver_from(ENV['order_receipt_from_email'])
+      expect(mail).to deliver_from(User.order_acknowledge_email_address)
     end
 
     it 'should indicate receipt of customer order' do

--- a/spec/mailers/order_notifier_spec.rb
+++ b/spec/mailers/order_notifier_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe OrderNotifier, :type => :mailer do
   include EmailSpec::Helpers
   include EmailSpec::Matchers
   
+  before(:each) do
+    FactoryGirl.create(:kitchen_user)
+  end
+  
   let(:order) { FactoryGirl.create(:order_with_items) }
   
   describe 'customer' do
@@ -18,7 +22,7 @@ RSpec.describe OrderNotifier, :type => :mailer do
     end
     
     it 'should specify correct from address' do
-      expect(mail).to deliver_from('from@example.com')
+      expect(mail).to deliver_from(ENV['order_receipt_from_email'])
     end
 
     it 'should indicate receipt of customer order' do
@@ -38,8 +42,8 @@ RSpec.describe OrderNotifier, :type => :mailer do
   describe 'kitchen' do
     let(:mail)  { OrderNotifier.kitchen(order) }
     
-    it 'should specify delivery to kitchen address' do
-      expect(mail).to deliver_to('patmbolger@gmail.com')
+    it 'should specify delivery to admin address(es)' do
+      expect(mail).to deliver_to(ENV['order_receipt_from_email'])
     end
     
     it 'should specify correct subject' do
@@ -47,7 +51,7 @@ RSpec.describe OrderNotifier, :type => :mailer do
     end
     
     it 'should specify correct from address' do
-      expect(mail).to deliver_from('from@example.com')
+      expect(mail).to deliver_from(ENV['order_receipt_from_email'])
     end
 
     it 'should indicate receipt of customer order' do

--- a/spec/mailers/order_notifier_spec.rb
+++ b/spec/mailers/order_notifier_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe OrderNotifier, :type => :mailer do
     let(:mail)  { OrderNotifier.kitchen(order) }
     
     it 'should specify delivery to admin address(es)' do
-      expect(mail).to deliver_to(ENV['order_receipt_from_email'])
+      expect(mail).to deliver_to(User.notification_email_list)
     end
     
     it 'should specify correct subject' do

--- a/spec/mailers/order_notifier_spec.rb
+++ b/spec/mailers/order_notifier_spec.rb
@@ -4,13 +4,10 @@ RSpec.describe OrderNotifier, :type => :mailer do
   include EmailSpec::Helpers
   include EmailSpec::Matchers
   
-  before(:each) do
-    FactoryGirl.create(:kitchen_user)
-  end
-  
   let(:order) { FactoryGirl.create(:order_with_items) }
   
   describe 'customer' do
+
     let(:mail) { OrderNotifier.customer(order) }
 
     it 'should specify delivery to customer email address' do
@@ -22,7 +19,7 @@ RSpec.describe OrderNotifier, :type => :mailer do
     end
     
     it 'should specify correct from address' do
-      expect(mail).to deliver_from(ENV['order_receipt_from_email'])
+      expect(mail).to deliver_from(User.order_acknowledge_email_address)
     end
 
     it 'should indicate receipt of customer order' do

--- a/spec/mailers/previews/order_notifier_preview.rb
+++ b/spec/mailers/previews/order_notifier_preview.rb
@@ -1,12 +1,10 @@
 class OrderNotifierPreview < ActionMailer::Preview
   
   def kitchen
-    FactoryGirl.create(:kitchen_user)
     order = FactoryGirl.create(:order_with_items)
     OrderNotifier.kitchen(order)
   end
   def customer
-    FactoryGirl.create(:kitchen_user)
     order = FactoryGirl.create(:order_with_items)
     OrderNotifier.customer(order)
   end

--- a/spec/mailers/previews/order_notifier_preview.rb
+++ b/spec/mailers/previews/order_notifier_preview.rb
@@ -1,11 +1,14 @@
 class OrderNotifierPreview < ActionMailer::Preview
+  
   def kitchen
+    FactoryGirl.create(:kitchen_user)
     order = FactoryGirl.create(:order_with_items)
     OrderNotifier.kitchen(order)
   end
-  
   def customer
+    FactoryGirl.create(:kitchen_user)
     order = FactoryGirl.create(:order_with_items)
     OrderNotifier.customer(order)
   end
+
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe User, type: :model do
     before do
       3.times { FactoryGirl.create(:user) }
       @clients = User.where.not(is_admin: true)
-      @admin = FactoryGirl.create(:user, is_admin: true)
+      @admin = FactoryGirl.create(:user, is_admin: true, receive_notifications: true)
+      @kitchen_user = FactoryGirl.create(:kitchen_user)
     end
 
     context 'admin?' do
@@ -54,13 +55,23 @@ RSpec.describe User, type: :model do
 
     context ':admins scope' do
       it 'returns an array of admins' do
-        expect(User.admins).to match_array @admin
+        expect(User.admins).to match_array [@admin, @kitchen_user]
+      end
+      
+      it 'sends order notification to all admins' do
+        expect(User.notification_email_list).to match_array [@admin.email,    
+                                              @kitchen_user.email]
+      end
+      
+      it 'sends order receipt confirmation from kitchen admin' do
+        expect(User.order_acknowledge_email_address).to eq(@kitchen_user.email)
       end
 
       it 'excludes non admins' do
         expect(User.admins).to_not include @clients
       end
     end
+    
 
     context ':clients scope' do
       it 'returns an array of clients' do

--- a/spec/requests/api/v1/order_spec.rb
+++ b/spec/requests/api/v1/order_spec.rb
@@ -30,6 +30,7 @@ describe Api::V1::OrdersController do
   before(:each) do
     menu.menu_items_menus.create(menu_item: menu_item, daily_stock: 20)
     menu.menu_items_menus.create(menu_item: menu_item2, daily_stock: 20)
+    FactoryGirl.create(:kitchen_user)
   end
 
   describe 'menu.menu_items_menus' do


### PR DESCRIPTION
1. Added two fields to User model:
   a) 'receive_notifications' - receive notification email(s) for customer orders (must also be an admin)
   b) 'order_acknowledge_email' - the 'from' address for order receipt acknowledgement sent to customer
2. Added methods to User to return email addresses (for notification and 'default' _from_ address)
3. Added tests for above changes
4. Added new fields to AA views

https://www.pivotaltracker.com/n/projects/1321640/stories/96280146
