### PR TITLE
FIX: random spec failures based on unescaped characters in the orders email notifications

### DIFF
--- a/spec/mailers/order_notifier_spec.rb
+++ b/spec/mailers/order_notifier_spec.rb
@@ -1,11 +1,12 @@
 require "rails_helper"
+require "cgi"
 
 RSpec.describe OrderNotifier, :type => :mailer do
   include EmailSpec::Helpers
   include EmailSpec::Matchers
-  
+
   let(:order) { FactoryGirl.create(:order_with_items) }
-  
+
   describe 'customer' do
 
     let(:mail) { OrderNotifier.customer(order) }
@@ -13,11 +14,11 @@ RSpec.describe OrderNotifier, :type => :mailer do
     it 'should specify delivery to customer email address' do
       expect(mail).to deliver_to(order.user.email)
     end
-    
+
     it 'should specify correct subject' do
       expect(mail).to have_subject('Take-Away Order Receipt Confirmation')
     end
-    
+
     it 'should specify correct from address' do
       expect(mail).to deliver_from(User.order_acknowledge_email_address)
     end
@@ -25,11 +26,11 @@ RSpec.describe OrderNotifier, :type => :mailer do
     it 'should indicate receipt of customer order' do
       expect(mail).to have_body_text('Take-Away Order Receipt')
     end
-    
+
     it 'should contain customer name' do
-      expect(mail).to have_body_text(order.user.name)
+      expect(mail).to have_body_text(CGI.escapeHTML(order.user.name))
     end
-    
+
     it 'should have one or more items in the order' do
       expect(order.menu_items).not_to be_empty
     end
@@ -38,15 +39,15 @@ RSpec.describe OrderNotifier, :type => :mailer do
 
   describe 'kitchen' do
     let(:mail)  { OrderNotifier.kitchen(order) }
-    
+
     it 'should specify delivery to admin address(es)' do
       expect(mail).to deliver_to(User.notification_email_list)
     end
-    
+
     it 'should specify correct subject' do
       expect(mail).to have_subject('Order Received')
     end
-    
+
     it 'should specify correct from address' do
       expect(mail).to deliver_from(User.order_acknowledge_email_address)
     end
@@ -54,12 +55,12 @@ RSpec.describe OrderNotifier, :type => :mailer do
     it 'should indicate receipt of customer order' do
       expect(mail).to have_body_text('Order Recieved for Take Me Away')
     end
-    
+
     it 'should contain customer name and email' do
-      expect(mail).to have_body_text(order.user.name)
+      expect(mail).to have_body_text(CGI.escapeHTML(order.user.name))
       expect(mail).to have_body_text(order.user.email)
     end
-    
+
     it 'should have one or more items in the order' do
       expect(order.menu_items).not_to be_empty
     end


### PR DESCRIPTION
When the factory generates an `order` with  an `user.name` that has single quotes or other signs (e.g. o'Connor), the email fields come back as HTML escaped text (e.g. o&#39;Connor). This fix escapes the name fields to avoid random spec failures.
`o'Connor` -> `o&#39;Connor`
