### PR TITLE
PATCH: deleted unneeded migration file

### DIFF
--- a/db/migrate/20150623191448_remove_image_columns_from_menu_item.rb
+++ b/db/migrate/20150623191448_remove_image_columns_from_menu_item.rb
@@ -1,8 +1,0 @@
-class RemoveImageColumnsFromMenuItem < ActiveRecord::Migration
-  def change
-    remove_column :menu_items, :image_file_name, :string
-    remove_column :menu_items, :image_content_type, :string
-    remove_column :menu_items, :image_file_size, :integer
-    remove_column :menu_items, :image_updated_at, :datetime
-  end
-end


### PR DESCRIPTION
Removed unneeded migration file (associated with fields for paperclip management of images).
