### PR TITLE
Enable order create/update in ActiveAdmin (PT 990025966)

### DIFF
--- a/app/admin/order.rb
+++ b/app/admin/order.rb
@@ -5,7 +5,7 @@ ActiveAdmin.register Order do
   end
 
   permit_params :id, :user_id, :status, :order_time, :pickup_time, :fulfillment_time,
-    order_items_attributes: [:id, :menu_item_id, :quantity, :_destroy]
+    order_items_attributes: [:id, :menu_id, :menu_item_id, :quantity, :_destroy]
 
   scope 'Canceled', :canceled
   scope 'Pending', :pending, default: true
@@ -29,20 +29,6 @@ ActiveAdmin.register Order do
     resource.set_status('canceled')
     redirect_to admin_orders_path, notice: 'Canceled order'
   end
-
-  # create_table "orders", force: :cascade do |t|
-  #   t.integer  "user_id"
-  #   t.string   "status"
-  #   t.datetime "order_time"
-  #   t.datetime "pickup_time"
-  #   t.datetime "fulfillment_time"
-  #   t.datetime "created_at",       null: false
-  #   t.datetime "updated_at",       null: false
-  # end
-
-  #permit_params do
-  #  permitted = [:user_id, :status, :order_time, :pickup_time, :fulfillment_time, order_item: [:order_id, :menu_item_id, :quantity]]
-  #end
 
   index do
     selectable_column
@@ -72,13 +58,20 @@ ActiveAdmin.register Order do
       f.input :status, as: :select, collection: Order::STATUS
       f.input :order_time, as: :date_time_picker, datepicker_options: {format: 'Y-m-d H:i'}
       f.input :pickup_time, as: :date_time_picker, datepicker_options: {format: 'Y-m-d H:i'}
+      if not Menu.today.empty?
+        f.has_many :order_items, 
+                      heading: 'Items in this order:',
+                      new_record: 'Add Item',
+                      allow_destroy: true do |item_form|
+          item_form.input :menu, collection: Menu.today, include_blank: false
+          item_form.input :menu_item, collection: Menu.today[0].menu_items, 
+                          include_blank: false
+          item_form.input :quantity, as: :number
+        end
+      else
+        render inline: 'There are no menu items available today - add items to menu(s)'
+      end
     end
-
-    f.has_many :order_items, allow_destroy: true do |item_form|
-      item_form.input :menu_item, collection: MenuItem.all
-      item_form.input :quantity, as: :number
-    end
-
     f.actions
   end
 

--- a/app/assets/javascripts/menu_items.js
+++ b/app/assets/javascripts/menu_items.js
@@ -1,0 +1,37 @@
+var MenuItemsSelect = {
+  get_menu_items: function () {
+    var menu_id = $(this).val();  // the menu_id is the value of the selected item
+    var order_item_id = /\d+/.exec($(this).attr('name'))[0];
+    var action_url = '/menu_items/show/' + order_item_id + '/' + menu_id;
+    $.ajax({type: 'GET',
+            url: action_url,
+            timeout: 5000,
+            error: function (xhrObj, status, exception) {alert('Server Response Timeout!');},
+            success: function (data, status, xhrObject){
+              var ele = '#order_order_items_attributes_' + order_item_id + '_menu_item_id';
+              $(ele).html(data);
+              }
+            });
+    return(true);
+  },
+  setup: function () {
+    // Initialize the menu_items for each 'Add Item' (order_item) selection.  
+    // Without this init function, a reload of the page (due to model validation failure, 
+    // for example) will result in the correct menu appearing (that is, the menu selected before 
+    // submitting the form) but the incorrect menu_items list will appear - 
+    // that list will be the same as the initial menu_items selection list that
+    // appeared when the form was first presented.
+      
+    // Also note that this work-around results in the top-most menu_item being selected upon
+    // page reload.   The user will have to reselect another menu_item in the list if desired.
+    $('[id^=order_order_items_attributes_][id$=_menu_id]').each(MenuItemsSelect.get_menu_items);
+    
+    // Add change event callback to each order_item on the page.
+    // Note that this is added to the page 'body' but delegated to descendants - this is because
+    // descendents (order_item added via 'Add Item' button) can be added after 
+    // the initial load of the page.
+    $('body').on('change', '[id^=order_order_items_attributes_][id$=_menu_id]', MenuItemsSelect.get_menu_items);
+  }
+};
+
+$(MenuItemsSelect.setup);

--- a/app/controllers/menu_items_controller.rb
+++ b/app/controllers/menu_items_controller.rb
@@ -1,0 +1,9 @@
+class MenuItemsController < ApplicationController
+  def show
+    menu_id = params[:menu_id]
+    order_item_id = params[:order_item_id]
+    @menu_items = Menu.find(menu_id).menu_items
+    render(:partial => 'menu_items', :object => @menu_items, 
+            :locals => {order_item_id: order_item_id}) if request.xhr?
+  end
+end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -20,8 +20,11 @@ class Menu < ActiveRecord::Base
     end 
   end
  
-  scope :this_week, -> { where("start_date <= ? AND end_date >= ?",                               
+  scope :this_week, -> { where("start_date <= ? AND end_date >= ?",
                           Date.today.end_of_week, Date.today) }
+                          
+  scope :today,     -> { where("start_date <= ? AND end_date >= ?",
+                          Date.today, Date.today).order(:end_date) }                        
                           
   def self.item_in_menu?(item_to_check)
     # Checks whether the input menu_item is included in any current or future menu.

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,5 +1,7 @@
 class Order < ActiveRecord::Base
-  has_many :order_items
+  # New order create will validate order_items before the latter are created, hence
+  # we need 'inverse_of' as part of the association (see note re 'inverse_of' in Menu model).
+  has_many :order_items, inverse_of: :order, dependent: :destroy
   has_many :menu_items, through: :order_items
   belongs_to :user
 
@@ -10,7 +12,9 @@ class Order < ActiveRecord::Base
 
   validates_presence_of :user
 
-  validates :pickup_time, date: { after: Proc.new { Time.now }, message: '%{value} didn\'t pass validation'}
+  validates :pickup_time, date: { after: Proc.new { Time.now }, 
+      message: 'Pickup time must be later than current time'}
+      
   validates :status, inclusion: Order::STATUS
 
   scope :canceled, lambda { where(status: 'canceled') }

--- a/app/views/menu_items/_menu_items.erb
+++ b/app/views/menu_items/_menu_items.erb
@@ -1,0 +1,1 @@
+<%= select_tag("order[order_items_attributes][#{order_item_id}][menu_item_id]", options_from_collection_for_select(menu_items, 'id', 'name')) %>

--- a/app/views/order_notifier/kitchen.html.erb
+++ b/app/views/order_notifier/kitchen.html.erb
@@ -1,4 +1,4 @@
-<h1>Order Recieved for Take Me Away</h1>
+<h1>Order Received for Take Me Away</h1>
 
 <p>
   <br>

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module TakeMeAway
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = ENV['TZ']
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -174,7 +174,7 @@ ActiveAdmin.setup do |config|
   #   config.register_stylesheet 'my_print_stylesheet.css', media: :print
   #
   # To load a javascript file:
-  #   config.register_javascript 'my_javascript.js'
+  config.register_javascript 'menu_items.js'
 
   # == CSV options
   #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,4 +18,7 @@ Rails.application.routes.draw do
   end
 
   root to: 'admin/dashboard#index'
+  
+  get 'menu_items/show/:order_item_id/:menu_id' => 'menu_items#show', as: 'menu_items'
+  
 end

--- a/features/order_workflow.feature
+++ b/features/order_workflow.feature
@@ -16,29 +16,41 @@ Feature: As an admin
       | 2  | Beef    | 30    |
       
     And the following Menus exist:
-      | id | title   | start_date | end_date   |
-      | 1  | Monday  | 2015-01-01 | today      |
-      | 2  | Tuesday | 2015-01-02 | 2015-01-11 |
-
-    And the following Orders exist:
-      | order[id] | user[user] | order[pickup_time] | order[order_time] | menu_item[name] | menu[id] |
-      | 1         | Client1    | 2015-01-01         | 2015-01-01        | Monday          | 1        |
-      | 2         | Client2    | 2015-01-02         | 2015-01-02        | Tuesday         | 2        |
+      | id | title    | start_date | end_date   |
+      | 1  | Today    | today      | today      |
+      | 2  | ThisWeek | this_week  | this_week  |
+      | 3  | NextWeek | next_week  | next_week  |
 
     And I am logged in as admin
-    And I am on the "Orders" page
-    And I click the "All" link
 
   Scenario: View index
+    Given the following Orders exist:
+    | order[id]  | user[user] | order[pickup_time] | order[order_time] | menu_item[name] | menu[id] |
+    | 1          | Client1    | 2015-01-01         | 2015-01-01        | Chicken         | 1        |
+    | 2          | Client2    | 2015-01-02         | 2015-01-02        | Beef            | 2        |
+    And I am on the "Orders" page
+    And I click the "All" link
     Then I should see an index of "Orders"
     And I should see 2 record rows
 
   Scenario: View existing Order
+    Given the following Orders exist:
+    | order[id]  | user[user] | order[pickup_time] | order[order_time] | menu_item[name] | menu[id] |
+    | 1          | Client1    | 2015-01-01         | 2015-01-01        | Chicken         | 1        |
+    | 2          | Client2    | 2015-01-02         | 2015-01-02        | Beef            | 2        |
+    And I am on the "Orders" page
+    And I click the "All" link
     When I click the "view" link for "Order #1"
     Then I should be on the view page for Order "Order #1"
     And I should see "Order #1"
 
   Scenario: Toggle status
+    Given the following Orders exist:
+    | order[id]  | user[user] | order[pickup_time] | order[order_time] | menu_item[name] | menu[id] |
+    | 1          | Client1    | 2015-01-01         | 2015-01-01        | Chicken         | 1        |
+    | 2          | Client2    | 2015-01-02         | 2015-01-02        | Beef            | 2        |
+    And I am on the "Orders" page
+    And I click the "All" link
     When I click the "Change status" link for "Order #1"
     Then I should be on the "Orders" page
     And I should see "Changed status to 'processed'"
@@ -47,6 +59,12 @@ Feature: As an admin
     Then I should see "Changed status to 'pending'"
 
   Scenario: Cancel order
+    Given the following Orders exist:
+    | order[id]  | user[user] | order[pickup_time] | order[order_time] | menu_item[name] | menu[id] |
+    | 1          | Client1    | 2015-01-01         | 2015-01-01        | Chicken         | 1        |
+    | 2          | Client2    | 2015-01-02         | 2015-01-02        | Beef            | 2        |
+    And I am on the "Orders" page
+    And I click the "All" link
     When I click the "Cancel" link for "Order #2"
     Then I should be on the "Orders" page
     And I should see "Canceled order"
@@ -54,6 +72,34 @@ Feature: As an admin
     Then I should see 1 record rows
     And I should see "Order #2"
     And I should not see "Order #1"
+    
+  @javascript
+  Scenario: Create order
+    Given "Chicken" has been added as a MenuItem to "Today"
+    Given "Beef" has been added as a MenuItem to "ThisWeek"
+    And I am on the "Orders" page
+    When I click the "New Order" link
+    Then I should be on the "New Order" page
+    And I select "Client" to "Client1"
+    And I select the time "2015-08-20 10:00" in datepicker for Order Order Time
+    And I select the time "2015-08-20 13:00" in datepicker for Order Pickup Time
+    Then I click "Add Item"
+    And I should not be able to select "NextWeek"
+    And I should be able to select "Today"
+    And I should be able to select "ThisWeek"
+    And I select "first Order Menu" to "Today"
+    And I should be able to select "Chicken"
+    And I should not be able to select "Beef"
+    And I select "first Order Item" to "Chicken"
+    And I fill in "first Order Item quantity" with "1"
+    Then I click "Add Item"
+    And I select "second Order Menu" to "ThisWeek"
+    And I select "second Order Item" to "Beef"
+    And I fill in "second Order Item quantity" with "1"
+    And I click "Create Order" button
+    And I should see "Order was successfully created"
+    And I should see "Chicken"
+    And I should see "Beef"
     
 #  @javascript
 #  Scenario: Edit order

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -12,6 +12,10 @@ When(/^I fill in "([^"]*)" with "([^"]*)"$/) do |field, value|
       select_field = 'menu_menu_items_menus_attributes_0_daily_stock'
     when 'second Daily stock' then
       select_field = 'menu_menu_items_menus_attributes_1_daily_stock'
+    when 'first Order Item quantity'
+      select_field = 'order_order_items_attributes_0_quantity'
+    when 'second Order Item quantity'
+      select_field = 'order_order_items_attributes_1_quantity'
     else
       select_field = field
   end
@@ -52,9 +56,9 @@ end
 
 Then /^I should( not)? (?:see|be able to select) "([^"]*)"$/ do |negative, string|
   unless negative
-    expect(page).to have_text string
+    expect(page.body).to have_text string
   else
-    expect(page).to_not have_text string
+    expect(page.body).to_not have_text string
   end
 end
 
@@ -66,7 +70,7 @@ Then /^I should( not)? see link "([^"]*)"$/ do |negative, link|
   end
 end
 
-And(/^I select the date "([^"]*)" in datepicker for ([^"]*)$/) do |date, element|
+And(/^I select the (?:date|time) "([^"]*)" in datepicker for ([^"]*)$/) do |date, element|
   id = element.downcase.tr!(' ', '_')
   page.execute_script "$('input##{id}').val('#{date}');"
 end
@@ -83,6 +87,16 @@ When(/^I select "([^"]*)" to "([^"]*)"$/) do |field, option|
       id = 'menu_menu_items_menus_attributes_1_menu_item_id'
     when 'Menu Item Status' then
       id = 'menu_item_status'
+    when 'Client' then
+      id = 'order_user_id'
+    when 'first Order Menu'
+      id = 'order_order_items_attributes_0_menu_id'
+    when 'first Order Item'
+      id = 'order_order_items_attributes_0_menu_item_id'
+    when 'second Order Menu'
+      id = 'order_order_items_attributes_1_menu_id'
+    when 'second Order Item'
+      id = 'order_order_items_attributes_1_menu_item_id'
   end
   find(:select, id).find(:option, option).select_option
 end

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -19,6 +19,8 @@ def path_to(page_name, id = '')
       admin_admins_path
     when 'edit admin'then
       edit_admin_admin_path
+    when 'new order' then
+      new_admin_order_path
     else
       raise('path to specified is not listed in #path_to')
   end

--- a/spec/controllers/menu_items_controller_spec.rb
+++ b/spec/controllers/menu_items_controller_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+include ActionView::Helpers::FormTagHelper
+include ActionView::Helpers::FormOptionsHelper
+
+RSpec.describe MenuItemsController, :type => :controller do
+  render_views
+
+  let(:menu) { FactoryGirl.create(:menu_with_item) }
+
+  context 'Routing' do
+    it 'routes /menu_items/show/:order_item_id/:menu_id to menu_items#show' do
+      expect(get: '/menu_items/show/0/10').to route_to(
+            controller: 'menu_items', action: 'show', 
+            order_item_id: '0', menu_id: '10')
+    end
+  end
+  context 'AJAX fetch of menu items' do
+    before do
+      xhr :get, :show, order_item_id: 0, menu_id: menu.id
+    end
+    it 'assigns items for specified menu to @menu_items' do
+      expect(assigns(:menu_items)).to eq menu.menu_items
+    end
+    it 'renders partial to create HTML text' do
+      expect(response).to render_template(:_menu_items)
+    end
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+    it 'returns menu_item HTML select element' do
+      expect(response.body).to eq select_tag("order[order_items_attributes][0][menu_item_id]",
+          options_from_collection_for_select(menu.menu_items, 'id', 'name'))
+    end
+  end
+end

--- a/spec/mailers/order_notifier_spec.rb
+++ b/spec/mailers/order_notifier_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe OrderNotifier, :type => :mailer do
     end
 
     it 'should indicate receipt of customer order' do
-      expect(mail).to have_body_text('Order Recieved for Take Me Away')
+      expect(mail).to have_body_text('Order Received for Take Me Away')
     end
 
     it 'should contain customer name and email' do

--- a/spec/models/menu_spec.rb
+++ b/spec/models/menu_spec.rb
@@ -92,6 +92,20 @@ RSpec.describe Menu, type: :model do
         expect(@menu8.menu_items_menus[0].overlapping_menu).to be nil
       end
     end
+    context 'Checking scopes' do
+      it '#this_week includes correct menus for this week' do
+        expect(Menu.this_week).to include @menu3, @menu4, @menu6, @menu7, @menu8
+      end
+      it '#this_week excludes menus not active this week' do
+        expect(Menu.this_week).to_not include @menu1, @menu2, @menu5
+      end
+      it '#today includes menus active today' do
+        expect(Menu.today).to include @menu3, @menu7
+      end
+      it '#today excludes menus not active today' do
+        expect(Menu.today).to_not include @menu1, @menu2, @menu4, @menu5, @menu6, @menu8
+      end
+    end
     it 'destroys associated menu_items_menu records on menu delete' do
       expect{ @menu6.destroy }.to change(MenuItemsMenu, :count).by(-2)
     end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/99025966

1) Enable creation and edit of order in AA views
2) Configured setting for local timezone (via ENV var) to application.rb - enables app to work in local TZ
3) Corrected spelling error in mail notifier template
4) Added unit (rspec) tests for item 1 
5) Added acceptance test for item 1 

Limitations:
1) Daily stock quantity is not decremented when AA is used for order create/update (inventory management should be refactored in any case - will add item(s) to PT for that).
2) The list of menu_items presented for inclusion in order (during create/edit in AA) does not account for remaining daily stock quantity. (UPDATE: this limitation was addressed in PR #67)

These limitations are due to lack of complete control over model management logic in AA.

Overall, we can probably live with these limitations as the AA views are meant to be only a supplement to the primary mechanism for order creation (which is the front-end app).
