### PR TITLE
menu_item daily stock applies to each day item is active (PT100725538)

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -102,23 +102,23 @@ class Api::V1::OrdersController < ApiController
     @order.order_items.build(menu: Menu.find(menu_id),
                              menu_item: MenuItem.find(menu_item_id),
                              quantity: qty)
-    stock_service(menu_id, menu_item_id, -qty)
+    adjust_item_quantity_sold(menu_id, menu_item_id, qty)
   end
 
   def purge_order_items
     @order.order_items.each do |item|
-      stock_service(item.menu_id, item.menu_item_id, item.quantity)
+      adjust_item_quantity_sold(item.menu_id, item.menu_item_id, -item.quantity)
     end
     @order.order_items.delete_all
   end
 
-  def stock_service(menu_id, menu_item_id, qty)
+  def adjust_item_quantity_sold(menu_id, menu_item_id, qty)
     menu_item = MenuItem.find(menu_item_id)
     resource = menu_item.menus.find(menu_id).menu_items_menus.find_by(menu_item_id: menu_item_id)
     if qty < 0
-      StockInventory.decrement_inventory(resource, -qty)
+      StockInventory.decrement_sold(resource, -qty)
     else
-      StockInventory.increment_inventory(resource, qty)
+      StockInventory.increment_sold(resource, qty)
     end
   end
 

--- a/app/controllers/menu_items_controller.rb
+++ b/app/controllers/menu_items_controller.rb
@@ -2,7 +2,9 @@ class MenuItemsController < ApplicationController
   def show
     menu_id = params[:menu_id]
     order_item_id = params[:order_item_id]
-    @menu_items = Menu.find(menu_id).menu_items
+    menu_items_menus = Menu.find(menu_id).menu_items_menus
+    @menu_items = Array.new
+    menu_items_menus.each {|mim| @menu_items << mim.menu_item if mim.active? }
     render(:partial => 'menu_items', :object => @menu_items, 
             :locals => {order_item_id: order_item_id}) if request.xhr?
   end

--- a/app/models/menu_items_menu.rb
+++ b/app/models/menu_items_menu.rb
@@ -1,8 +1,15 @@
 class MenuItemsMenu < ActiveRecord::Base
   belongs_to :menu_item
   belongs_to :menu
-
-  validates :daily_stock, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  
+  before_create :set_quantity_sold
+  def set_quantity_sold
+    self.quantity_sold = 0
+    self.quantity_sold_date = Date.today
+  end
+  
+  validates :daily_stock, presence: true, 
+        numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :menu_item, presence: true
   validates :menu, presence: true
   
@@ -42,15 +49,22 @@ class MenuItemsMenu < ActiveRecord::Base
     nil
   end
 
-  def decrement_stock(qty)
-    self.decrement!(:daily_stock, qty)
+  def decrement_quantity_sold(qty)
+    self.decrement!(:quantity_sold, qty)
   end
 
-  def increment_stock(qty)
-    self.increment!(:daily_stock, qty)
+  def increment_quantity_sold(qty)
+    self.increment!(:quantity_sold, qty)
   end
 
   def active?
-    self.daily_stock > 0
+    # If this is the first time today that this menu_items_menu is to be included in a menu,
+    # reset quantity_sold (for today) to zero
+    if self.quantity_sold_date != (date_today = Date.today)
+      self.quantity_sold = 0
+      self.quantity_sold_date = date_today
+    end
+    # 'daily_stock' is the maximum quantity of the item that can sold on any given day.
+    self.quantity_sold < self.daily_stock
   end
 end

--- a/db/migrate/20150830104414_add_daily_stock_fields_to_menu_items_menu.rb
+++ b/db/migrate/20150830104414_add_daily_stock_fields_to_menu_items_menu.rb
@@ -1,0 +1,6 @@
+class AddDailyStockFieldsToMenuItemsMenu < ActiveRecord::Migration
+  def change
+    add_column :menu_items_menus, :quantity_sold, :integer
+    add_column :menu_items_menus, :quantity_sold_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150618181851) do
+ActiveRecord::Schema.define(version: 20150830104414) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,8 @@ ActiveRecord::Schema.define(version: 20150618181851) do
     t.integer "menu_item_id"
     t.integer "menu_id"
     t.integer "daily_stock"
+    t.integer "quantity_sold"
+    t.date    "quantity_sold_date"
   end
 
   add_index "menu_items_menus", ["menu_id"], name: "index_menu_items_menus_on_menu_id", using: :btree

--- a/features/order_workflow.feature
+++ b/features/order_workflow.feature
@@ -81,8 +81,8 @@ Feature: As an admin
     When I click the "New Order" link
     Then I should be on the "New Order" page
     And I select "Client" to "Client1"
-    And I select the time "2015-08-20 10:00" in datepicker for Order Order Time
-    And I select the time "2015-08-20 13:00" in datepicker for Order Pickup Time
+    And I select the time "tomorrow 10:00" in datepicker for Order Order Time
+    And I select the time "tomorrow 13:00" in datepicker for Order Pickup Time
     Then I click "Add Item"
     And I should not be able to select "NextWeek"
     And I should be able to select "Today"

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -72,6 +72,7 @@ end
 
 And(/^I select the (?:date|time) "([^"]*)" in datepicker for ([^"]*)$/) do |date, element|
   id = element.downcase.tr!(' ', '_')
+  date = date.sub('tomorrow', "#{Date.tomorrow}")
   page.execute_script "$('input##{id}').val('#{date}');"
 end
 

--- a/lib/stock_inventory.rb
+++ b/lib/stock_inventory.rb
@@ -1,9 +1,9 @@
 module StockInventory
-  def self.decrement_inventory(resource, qty)
-    resource.decrement_stock(qty)
+  def self.decrement_sold(resource, qty)
+    resource.decrement_quantity_sold(qty)
   end
 
-  def self.increment_inventory(resource, qty)
-    resource.increment_stock(qty)
+  def self.increment_sold(resource, qty)
+    resource.increment_quantity_sold(qty)
   end
 end

--- a/spec/requests/api/v1/order_spec.rb
+++ b/spec/requests/api/v1/order_spec.rb
@@ -67,11 +67,11 @@ describe Api::V1::OrdersController do
                                             'price' => menu_item.price.to_f }])
       end
 
-      it 'decrements MenuItemMenu by quantity after creating the order' do
+      it 'increments MenuItemMenu quantity_sold after creating the order' do
         post '/v1/orders', params.to_json
 
         menu_item_instance = menu.menu_items_menus.find_by(menu_item_id: menu_item.id)
-        expect(menu_item_instance.daily_stock).to eq 19
+        expect(menu_item_instance.quantity_sold).to eq 1
       end
 
       it 'send notification emails to kitchen and to customer' do


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/100725538

1) Refactored inventory management _from_ decrementing 'daily_stock' for each order _to_ incrementing 'quantity_sold' for each order.
2) On each day, reset 'quantity_sold' for each menu_item occurring in a menu sent to the FE (this is set to zero when the item is first added to a FE menu).
3) A menu_item is included in a menu sent to FE if it is active.  The item is active if quantity_sold is less then 'daily_stock'.
4) Misc: fixed cucumber test step (in features/order_workflow.feature and features/step_definitions/basic_steps.rb) that caused test failure due to order entry time occurring in the past (before time "now").
