### PR TITLE
Do not include expired menu in overlapping menu check

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -102,23 +102,23 @@ class Api::V1::OrdersController < ApiController
     @order.order_items.build(menu: Menu.find(menu_id),
                              menu_item: MenuItem.find(menu_item_id),
                              quantity: qty)
-    stock_service(menu_id, menu_item_id, -qty)
+    adjust_item_quantity_sold(menu_id, menu_item_id, qty)
   end
 
   def purge_order_items
     @order.order_items.each do |item|
-      stock_service(item.menu_id, item.menu_item_id, item.quantity)
+      adjust_item_quantity_sold(item.menu_id, item.menu_item_id, -item.quantity)
     end
     @order.order_items.delete_all
   end
 
-  def stock_service(menu_id, menu_item_id, qty)
+  def adjust_item_quantity_sold(menu_id, menu_item_id, qty)
     menu_item = MenuItem.find(menu_item_id)
     resource = menu_item.menus.find(menu_id).menu_items_menus.find_by(menu_item_id: menu_item_id)
     if qty < 0
-      StockInventory.decrement_inventory(resource, -qty)
+      StockInventory.decrement_sold(resource, -qty)
     else
-      StockInventory.increment_inventory(resource, qty)
+      StockInventory.increment_sold(resource, qty)
     end
   end
 

--- a/app/controllers/menu_items_controller.rb
+++ b/app/controllers/menu_items_controller.rb
@@ -2,7 +2,9 @@ class MenuItemsController < ApplicationController
   def show
     menu_id = params[:menu_id]
     order_item_id = params[:order_item_id]
-    @menu_items = Menu.find(menu_id).menu_items
+    menu_items_menus = Menu.find(menu_id).menu_items_menus
+    @menu_items = Array.new
+    menu_items_menus.each {|mim| @menu_items << mim.menu_item if mim.active? }
     render(:partial => 'menu_items', :object => @menu_items, 
             :locals => {order_item_id: order_item_id}) if request.xhr?
   end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -13,11 +13,23 @@ class Menu < ActiveRecord::Base
   validates :end_date, presence: true
   
   validate  :end_date_not_earlier_than_start_date
+  validate  :items_not_in_overlapping_menu
   
   def end_date_not_earlier_than_start_date
     if end_date && (end_date < start_date)
       errors[:end_date] << 'must be not be earlier than start date'
     end 
+  end
+  
+  validate  :items_not_in_overlapping_menu
+  def items_not_in_overlapping_menu
+    if self.menu_items_menus
+      self.menu_items_menus.each do |mim|
+        if (not mim.marked_for_destruction?) && (err_msg = mim.overlapping_menu)
+          errors[:item] << err_msg
+        end
+      end
+    end
   end
  
   scope :this_week, -> { where("start_date <= ? AND end_date >= ?",

--- a/app/models/menu_items_menu.rb
+++ b/app/models/menu_items_menu.rb
@@ -1,21 +1,39 @@
 class MenuItemsMenu < ActiveRecord::Base
   belongs_to :menu_item
-  belongs_to :menu
-
-  validates :daily_stock, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  belongs_to :menu, inverse_of: :menu_items_menus
+  
+  before_create :set_quantity_sold
+  def set_quantity_sold
+    self.quantity_sold = 0
+    self.quantity_sold_date = Date.today
+  end
+  
+  validates :daily_stock, presence: true, 
+        numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :menu_item, presence: true
   validates :menu, presence: true
   
-  validate :item_not_in_overlapping_menu
-  
-  def item_not_in_overlapping_menu
-    if (err_msg = overlapping_menu)
-      errors[:item] << err_msg
-    end
+  def decrement_quantity_sold(qty)
+    self.decrement!(:quantity_sold, qty)
   end
-  
+
+  def increment_quantity_sold(qty)
+    self.increment!(:quantity_sold, qty)
+  end
+
+  def active?
+    # If this is the first time today that this menu_items_menu is to be included in a menu,
+    # reset quantity_sold (for today) to zero
+    if self.quantity_sold_date != (date_today = Date.today)
+      self.quantity_sold = 0
+      self.quantity_sold_date = date_today
+    end
+    # 'daily_stock' is the maximum quantity of the item that can sold on any given day.
+    self.quantity_sold < self.daily_stock
+  end
+    
   def overlapping_menu
-    # Checks whether menu_item associated with 'self' is also included
+    # Checks whether menu_item associated with menu_item_menu is also included
     # in any "overlapping" menu ("overlap" means that the two menus span one or
     # more common days and include one or more common items)
     
@@ -26,9 +44,11 @@ class MenuItemsMenu < ActiveRecord::Base
     this_menu = self.menu
     
     self.menu_item.menus.each do |other_menu|
-      next if this_menu.id && this_menu.id == other_menu.id
+      next if this_menu.id == other_menu.id
+      # Check if other_menu overlaps this_menu and is not ended
       if this_menu.start_date <= other_menu.end_date && 
-         this_menu.end_date   >= other_menu.start_date
+         this_menu.end_date   >= other_menu.start_date &&
+         other_menu.end_date >= Date.today
         overlap_count += 1
         overlap += (overlap.empty? ? "'#{other_menu.title}'" : ", '#{other_menu.title}'")
       end
@@ -41,16 +61,5 @@ class MenuItemsMenu < ActiveRecord::Base
     end
     nil
   end
-
-  def decrement_stock(qty)
-    self.decrement!(:daily_stock, qty)
-  end
-
-  def increment_stock(qty)
-    self.increment!(:daily_stock, qty)
-  end
-
-  def active?
-    self.daily_stock > 0
-  end
+  
 end

--- a/db/migrate/20150830104414_add_daily_stock_fields_to_menu_items_menu.rb
+++ b/db/migrate/20150830104414_add_daily_stock_fields_to_menu_items_menu.rb
@@ -1,0 +1,6 @@
+class AddDailyStockFieldsToMenuItemsMenu < ActiveRecord::Migration
+  def change
+    add_column :menu_items_menus, :quantity_sold, :integer
+    add_column :menu_items_menus, :quantity_sold_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150618181851) do
+ActiveRecord::Schema.define(version: 20150830104414) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,8 @@ ActiveRecord::Schema.define(version: 20150618181851) do
     t.integer "menu_item_id"
     t.integer "menu_id"
     t.integer "daily_stock"
+    t.integer "quantity_sold"
+    t.date    "quantity_sold_date"
   end
 
   add_index "menu_items_menus", ["menu_id"], name: "index_menu_items_menus_on_menu_id", using: :btree

--- a/features/menu_workflow.feature
+++ b/features/menu_workflow.feature
@@ -12,6 +12,7 @@ Feature:
       | Friday   | 2015-01-04 | 2015-01-11 |
       | Saturday | 2015-01-05 | 2015-01-11 |
       | Today    | today      | today      |
+      | Today2   | today2     | today2     |
       | ThisWeek | this_week  | this_week  |
       | NextWeek | next_week  | next_week  |
 
@@ -27,12 +28,12 @@ Feature:
 
   Scenario: View index
     Then I should see an index of "Menus"
-    And I should see 8 record rows
+    And I should see 9 record rows
     
   Scenario: View index for this week
     When I click the "Current week" link
     Then I should see an index of "Menus"
-    And I should see 2 record rows
+    And I should see 3 record rows
     And I should see "Today"
     And I should see "ThisWeek"
     And I should not see "Monday"
@@ -80,7 +81,7 @@ Feature:
     And I should see "Menu was successfully destroyed."
     And I click the "All" link
     Then I should see an index of "Menus"
-    And I should see 7 record rows
+    And I should see 8 record rows
 
  @javascript
  Scenario: Add MenuItem to menu
@@ -106,20 +107,20 @@ Feature:
 
  @javascript
  Scenario: Add conflicting MenuItem to menu
-   Given "Chicken" has been added as a MenuItem to "Thursday"
-   And "Beef" has been added as a MenuItem to "Friday"
-   When I click the "edit" link for "Friday"
+   Given "Chicken" has been added as a MenuItem to "Today"
+   And "Beef" has been added as a MenuItem to "Today2"
+   When I click the "edit" link for "Today2"
    And I click "Add Item"
    And I select "first Menu Item" to "Chicken"
    And I fill in "first Daily stock" with "10"
    And I click "Update Menu" button
-   Then I should see "Item 'Chicken' is included in overlapping menu 'Thursday'"
+   Then I should see "Item 'Chicken' is included in overlapping menu 'Today'"
    
  @javascript
  Scenario: Add conflicting MenuItem(s) to menu
-    Given "Chicken" has been added as a MenuItem to "Friday"
-    And "Beef" has been added as a MenuItem to "Thursday"
-    When I click the "edit" link for "Saturday"
+    Given "Chicken" has been added as a MenuItem to "Today"
+    And "Beef" has been added as a MenuItem to "Today2"
+    When I click the "edit" link for "ThisWeek"
     And I click "Add Item"
     And I select "first Menu Item" to "Chicken"
     And I fill in "first Daily stock" with "10"
@@ -127,7 +128,7 @@ Feature:
     And I select "second Menu Item" to "Beef"
     And I fill in "second Daily stock" with "5"
     And I click "Update Menu" button
-    Then I should see "Item 'Chicken' is included in overlapping menu 'Friday' and 'Beef' is included in overlapping menu 'Thursday'"
+    Then I should see "Item 'Chicken' is included in overlapping menu 'Today' and 'Beef' is included in overlapping menu 'Today2'"
 
 
 

--- a/features/order_workflow.feature
+++ b/features/order_workflow.feature
@@ -81,8 +81,8 @@ Feature: As an admin
     When I click the "New Order" link
     Then I should be on the "New Order" page
     And I select "Client" to "Client1"
-    And I select the time "2015-08-20 10:00" in datepicker for Order Order Time
-    And I select the time "2015-08-20 13:00" in datepicker for Order Pickup Time
+    And I select the time "tomorrow 10:00" in datepicker for Order Order Time
+    And I select the time "tomorrow 13:00" in datepicker for Order Pickup Time
     Then I click "Add Item"
     And I should not be able to select "NextWeek"
     And I should be able to select "Today"

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -72,6 +72,7 @@ end
 
 And(/^I select the (?:date|time) "([^"]*)" in datepicker for ([^"]*)$/) do |date, element|
   id = element.downcase.tr!(' ', '_')
+  date = date.sub('tomorrow', "#{Date.tomorrow}")
   page.execute_script "$('input##{id}').val('#{date}');"
 end
 

--- a/features/step_definitions/fixtures_steps.rb
+++ b/features/step_definitions/fixtures_steps.rb
@@ -6,8 +6,8 @@ end
 
 Given(/^the following Menus exist:$/) do |table|
   table.hashes.each do |hash|
-    hash['start_date'] = Date.today if hash['start_date'] == 'today'
-    hash['end_date']   = Date.today if hash['end_date']   == 'today'
+    hash['start_date'] = Date.today if hash['start_date'] =~ /^today/
+    hash['end_date']   = Date.today if hash['end_date']   =~ /^today/
     hash['start_date'] = Date.today.beginning_of_week  if hash['start_date'] == 'this_week'
     hash['end_date']   = Date.today.end_of_week        if hash['end_date']   == 'this_week'
     hash['start_date'] = 1.week.from_now  if hash['start_date'] == 'next_week'

--- a/lib/stock_inventory.rb
+++ b/lib/stock_inventory.rb
@@ -1,9 +1,9 @@
 module StockInventory
-  def self.decrement_inventory(resource, qty)
-    resource.decrement_stock(qty)
+  def self.decrement_sold(resource, qty)
+    resource.decrement_quantity_sold(qty)
   end
 
-  def self.increment_inventory(resource, qty)
-    resource.increment_stock(qty)
+  def self.increment_sold(resource, qty)
+    resource.increment_quantity_sold(qty)
   end
 end

--- a/spec/requests/api/v1/order_spec.rb
+++ b/spec/requests/api/v1/order_spec.rb
@@ -67,11 +67,11 @@ describe Api::V1::OrdersController do
                                             'price' => menu_item.price.to_f }])
       end
 
-      it 'decrements MenuItemMenu by quantity after creating the order' do
+      it 'increments MenuItemMenu quantity_sold after creating the order' do
         post '/v1/orders', params.to_json
 
         menu_item_instance = menu.menu_items_menus.find_by(menu_item_id: menu_item.id)
-        expect(menu_item_instance.daily_stock).to eq 19
+        expect(menu_item_instance.quantity_sold).to eq 1
       end
 
       it 'send notification emails to kitchen and to customer' do


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/102510666

Fix is to exclude expired menus (end_date < today) from overlapping menus check.  (that is, an expired menu could still be "overlapping" with the edited menu, but we don't care about common menu_items between the two menus since the overlapping menu is, in fact, ended)
